### PR TITLE
fix: update bookmarklet URL due to RawGit shutdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,8 +74,8 @@ GPA =（學分 × 點數）的總和 / 總學分</pre>
               <h3>步驟 1 : 選擇你的計算機制，並將下面選擇的按鈕拖拉到你的書籤列。</h3>
               <div class="col-md-12">
                 <h5>
-                  <a class="btn btn-default" href="javascript:(function(){var script=document.createElement('SCRIPT');script.src='https://rawgit.com/ctxhou/NCKU-GPA-calculator/gh-pages/bookmarklet/ncku-gpa-calculator.js';document.body.appendChild(script);})()">舊制 NCKU GPA計算機</a>
-                    <a class="btn btn-default" href="javascript:(function(){var script=document.createElement('SCRIPT');script.src='https://rawgit.com/ctxhou/NCKU-GPA-calculator/gh-pages/bookmarklet/ncku-gpa-calculator-new.js';document.body.appendChild(script);})()">新制 NCKU GPA計算機</a>
+                  <a class="btn btn-default" href="javascript:(function(){var script=document.createElement('SCRIPT');script.src='https://cdn.jsdelivr.net/gh/ctxhou/NCKU-GPA-calculator@gh-pages/bookmarklet/ncku-gpa-calculator.js';document.body.appendChild(script);})()">舊制 NCKU GPA計算機</a>
+                    <a class="btn btn-default" href="javascript:(function(){var script=document.createElement('SCRIPT');script.src='https://cdn.jsdelivr.net/gh/ctxhou/NCKU-GPA-calculator@gh-pages/bookmarklet/ncku-gpa-calculator-new.js';document.body.appendChild(script);})()">新制 NCKU GPA計算機</a>
                 </h5>
 
                   <h6>顯示書籤列的方法：<a href="http://google.22ace.com/2013/08/google-chrome-bookmarks.html">Chrome</a> | <a href="https://support.mozilla.org/zh-TW/kb/bookmarks-toolbar-display-favorite-websites?esab=a&s=書籤列&r=2&as=s#w_agcjnioguauigciceinu">Firefox</a> （ 強烈不建議使用IE ）</h6>


### PR DESCRIPTION
RawGit CDN has been shut down, so I replace the bookmarklet URL using the jsDelivr service to restore functionality.

> RawGit is no longer actively developed. You should use [jsDelivr](https://www.jsdelivr.com/rawgit) instead. If you arrived here via any website other than rawgit.com, that website is not associated with this project and is not maintained by this project's maintainers (even if it uses this code).
> 
> from: https://github.com/rgrove/rawgit